### PR TITLE
feat: use md-5 to cache generated script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,7 @@ jobs:
         with:
             RUSTTARGET: ${{ matrix.binary_target }}
             ARCHIVE_TYPES: tar.gz
-            ARCHIVE_NAME: yamis-${{ github.ref_name }}-${{ matrix.target }}
+            ARCHIVE_NAME: yamis-${{ github.ref_name }}-${{ matrix.binary_target }}
             EXTRA_FILES: "README.md LICENSE CHANGELOG.md"
             TOOLCHAIN_VERSION: "stable"
             UPLOAD_MODE: none
@@ -74,9 +74,9 @@ jobs:
         if: matrix.builder == 'rust-build-action'
         # These should match the python script below
         run: |
-          mkdir -p ${{ env.ARTIFACT_DIR }}
-          mv ${{ steps.compile.outputs.BUILT_ARCHIVE }} ${{ env.ARTIFACT_DIR }}/yamis-${{ github.ref_name }}-${{ matrix.binary_target }}
-          mv ${{ steps.compile.outputs.BUILT_CHECKSUM }} ${{ env.ARTIFACT_DIR }}/yamis-${{ github.ref_name }}-${{ matrix.binary_target }}.sha256
+          sudo mkdir -p ${{ env.ARTIFACT_DIR }}
+          sudo mv ${{ steps.compile.outputs.BUILT_ARCHIVE }} ${{ env.ARTIFACT_DIR }}/yamis-${{ github.ref_name }}-${{ matrix.binary_target }}.tar.gz
+          sudo mv ${{ steps.compile.outputs.BUILT_CHECKSUM }} ${{ env.ARTIFACT_DIR }}/yamis-${{ github.ref_name }}-${{ matrix.binary_target }}.sha256
 
       - name: Setup Python 3
         if: matrix.builder == 'cross'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,20 +18,30 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # Note that we use different solutions to build for different targets.
+          # For musl there are issues with openssl, but with rust build action it works fine
+          # This action however does not work with certain other targets, so we only use it for musl
           - os: ubuntu-latest
             binary_target: x86_64-unknown-linux-gnu
+            builder: cross
           - os: ubuntu-latest
             binary_target: x86_64-unknown-linux-musl
+            builder: rust-build-action
           - os: windows-latest
             binary_target: x86_64-pc-windows-msvc
+            builder: cross
           - os: macos-latest
             binary_target: x86_64-apple-darwin
+            builder: cross
           - os: macos-latest
             binary_target: aarch64-apple-darwin
+            builder: cross
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
       - name: Install toolchain
+        if: matrix.builder == 'cross'
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -39,15 +49,16 @@ jobs:
           default: true
           profile: minimal
           override: true
+
       - name: Build target
+        if: matrix.builder == 'cross'
         uses: actions-rs/cargo@v1
         with:
           use-cross: true
           command: build
           args: --release --target ${{ matrix.binary_target }} --target-dir ${{ env.TARGET_DIR }}
+
       - name: Compile
-        # For musl there are issues with openssl, but with this action it should work
-        # This action however does not work with certain other targets, so we only use it for musl
         if: matrix.binary_target == 'x86_64-unknown-linux-musl'
         id: compile
         uses: rust-build/rust-build.action@v1.3.2
@@ -58,21 +69,25 @@ jobs:
             EXTRA_FILES: "README.md LICENSE CHANGELOG.md"
             TOOLCHAIN_VERSION: "stable"
             UPLOAD_MODE: none
+
       - name: Move musl binary
-        if: matrix.binary_target == 'x86_64-unknown-linux-musl'
+        if: matrix.builder == 'rust-build-action'
         # These should match the python script below
         run: |
           mkdir -p ${{ env.ARTIFACT_DIR }}
           mv ${{ steps.compile.outputs.BUILT_ARCHIVE }} ${{ env.ARTIFACT_DIR }}/yamis-${{ github.ref_name }}-${{ matrix.binary_target }}
           mv ${{ steps.compile.outputs.BUILT_CHECKSUM }} ${{ env.ARTIFACT_DIR }}/yamis-${{ github.ref_name }}-${{ matrix.binary_target }}.sha256
+
       - name: Setup Python 3
-        if: matrix.binary_target != 'x86_64-unknown-linux-musl'
+        if: matrix.builder == 'cross'
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
+
       - name: Package
-        if: matrix.binary_target != 'x86_64-unknown-linux-musl'
+        if: matrix.builder == 'cross'
         run: python -m ci_build ${{ env.TARGET_DIR }} ${{ matrix.binary_target }} ${{  github.ref_name }} ${{ env.ARTIFACT_DIR }}
+
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
         run: |
           sudo mkdir -p ${{ env.ARTIFACT_DIR }}
           sudo mv ${{ steps.compile.outputs.BUILT_ARCHIVE }} ${{ env.ARTIFACT_DIR }}/yamis-${{ github.ref_name }}-${{ matrix.binary_target }}.tar.gz
-          sudo mv ${{ steps.compile.outputs.BUILT_CHECKSUM }} ${{ env.ARTIFACT_DIR }}/yamis-${{ github.ref_name }}-${{ matrix.binary_target }}.sha256
+          sudo mv ${{ steps.compile.outputs.BUILT_CHECKSUM }} ${{ env.ARTIFACT_DIR }}/yamis-${{ github.ref_name }}-${{ matrix.binary_target }}.tar.gz.sha256
 
       - name: Setup Python 3
         if: matrix.builder == 'cross'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,30 +18,21 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Note that we use different solutions to build for different targets.
-          # For musl there are issues with openssl, but with rust build action it works fine
-          # This action however does not work with certain other targets, so we only use it for musl
           - os: ubuntu-latest
             binary_target: x86_64-unknown-linux-gnu
-            builder: cross
           - os: ubuntu-latest
             binary_target: x86_64-unknown-linux-musl
-            builder: rust-build-action
           - os: windows-latest
             binary_target: x86_64-pc-windows-msvc
-            builder: cross
           - os: macos-latest
             binary_target: x86_64-apple-darwin
-            builder: cross
           - os: macos-latest
             binary_target: aarch64-apple-darwin
-            builder: cross
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
       - name: Install toolchain
-        if: matrix.builder == 'cross'
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -51,41 +42,18 @@ jobs:
           override: true
 
       - name: Build target
-        if: matrix.builder == 'cross'
         uses: actions-rs/cargo@v1
         with:
           use-cross: true
           command: build
           args: --release --target ${{ matrix.binary_target }} --target-dir ${{ env.TARGET_DIR }}
 
-      - name: Compile
-        if: matrix.binary_target == 'x86_64-unknown-linux-musl'
-        id: compile
-        uses: rust-build/rust-build.action@v1.3.2
-        with:
-            RUSTTARGET: ${{ matrix.binary_target }}
-            ARCHIVE_TYPES: tar.gz
-            ARCHIVE_NAME: yamis-${{ github.ref_name }}-${{ matrix.binary_target }}
-            EXTRA_FILES: "README.md LICENSE CHANGELOG.md"
-            TOOLCHAIN_VERSION: "stable"
-            UPLOAD_MODE: none
-
-      - name: Move musl binary
-        if: matrix.builder == 'rust-build-action'
-        # These should match the python script below
-        run: |
-          sudo mkdir -p ${{ env.ARTIFACT_DIR }}
-          sudo mv ${{ steps.compile.outputs.BUILT_ARCHIVE }} ${{ env.ARTIFACT_DIR }}/yamis-${{ github.ref_name }}-${{ matrix.binary_target }}.tar.gz
-          sudo mv ${{ steps.compile.outputs.BUILT_CHECKSUM }} ${{ env.ARTIFACT_DIR }}/yamis-${{ github.ref_name }}-${{ matrix.binary_target }}.tar.gz.sha256
-
       - name: Setup Python 3
-        if: matrix.builder == 'cross'
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
 
       - name: Package
-        if: matrix.builder == 'cross'
         run: python -m ci_build ${{ env.TARGET_DIR }} ${{ matrix.binary_target }} ${{  github.ref_name }} ${{ env.ARTIFACT_DIR }}
 
       - name: Upload artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,11 +45,33 @@ jobs:
           use-cross: true
           command: build
           args: --release --target ${{ matrix.binary_target }} --target-dir ${{ env.TARGET_DIR }}
+      - name: Compile
+        # For musl there are issues with openssl, but with this action it should work
+        # This action however does not work with certain other targets, so we only use it for musl
+        if: matrix.binary_target == 'x86_64-unknown-linux-musl'
+        id: compile
+        uses: rust-build/rust-build.action@v1.3.2
+        with:
+            RUSTTARGET: ${{ matrix.binary_target }}
+            ARCHIVE_TYPES: tar.gz
+            ARCHIVE_NAME: yamis-${{ github.ref_name }}-${{ matrix.target }}
+            EXTRA_FILES: "README.md LICENSE CHANGELOG.md"
+            TOOLCHAIN_VERSION: "stable"
+            UPLOAD_MODE: none
+      - name: Move musl binary
+        if: matrix.binary_target == 'x86_64-unknown-linux-musl'
+        # These should match the python script below
+        run: |
+          mkdir -p ${{ env.ARTIFACT_DIR }}
+          mv ${{ steps.compile.outputs.BUILT_ARCHIVE }} ${{ env.ARTIFACT_DIR }}/yamis-${{ github.ref_name }}-${{ matrix.binary_target }}
+          mv ${{ steps.compile.outputs.BUILT_CHECKSUM }} ${{ env.ARTIFACT_DIR }}/yamis-${{ github.ref_name }}-${{ matrix.binary_target }}.sha256
       - name: Setup Python 3
+        if: matrix.binary_target != 'x86_64-unknown-linux-musl'
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
       - name: Package
+        if: matrix.binary_target != 'x86_64-unknown-linux-musl'
         run: python -m ci_build ${{ env.TARGET_DIR }} ${{ matrix.binary_target }} ${{  github.ref_name }} ${{ env.ARTIFACT_DIR }}
       - name: Upload artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,8 @@
 
 on:
   push:
+    branches:
+      - "*"
     paths:
       - 'src/**'
       - 'Cargo.toml'

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 /target
-ilocal.yamis.toml
+local.yamis.*
 /target_cov
 /target_ci

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 local.yamis.*
 /target_cov
 /target_ci
+/.idea
+/.vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.2.0] - 2023-01-14
+### Added
+- Add option to print task name and config file path when running tasks.
+
+### Changed
+- A hash is generated and used as part of the name of the scripts saved in the temporal
+ directory, so that they can be reused if the same script with same parameters is called
+ again.
 
 ## [1.1.0] - 2022-10-15
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## [1.1.0] - 2022-10-13
+## [1.1.0] - 2022-10-14
 ### Added
 - Upgrade to the latest version by running with the `--update` option.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 # Changelog
 
 
-## [1.1.0] - 2022-10-14
+## [1.1.0] - 2022-10-15
 ### Added
 - Upgrade to the latest version by running with the `--update` option.
 
 ### Changed
 - Improve the update information process.
+- Use rustls instead of openssl. Fixes some dependency issues on linux.
 
 ## [1.0.1] - 2022-10-11
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,22 +187,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -383,21 +367,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -613,19 +582,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper",
- "native-tls",
- "tokio",
- "tokio-native-tls",
-]
-
-[[package]]
 name = "idna"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -768,24 +724,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd7e2f3618557f980e0b17e8856252eee3c97fa12c54dff0ca290fb6266ca4a9"
-dependencies = [
- "lazy_static",
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "nix"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -842,51 +780,6 @@ name = "once_cell"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "074864da206b4973b84eb91683020dbefd6a8c3f0f38e054d93954e891935e4e"
-
-[[package]]
-name = "openssl"
-version = "0.10.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12fc0523e3bd51a692c8850d075d74dc062ccf251c0110668cbd921917118a13"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.76"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5230151e44c0f05157effb743e8d517472843121cf9243e8b81393edb5acd9ce"
-dependencies = [
- "autocfg",
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "os_str_bytes"
@@ -965,12 +858,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "pkg-config"
-version = "0.3.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "predicates"
@@ -1121,12 +1008,10 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
- "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -1136,7 +1021,6 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
  "tower-service",
  "url",
@@ -1199,16 +1083,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "schannel"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
-dependencies = [
- "lazy_static",
- "windows-sys",
-]
-
-[[package]]
 name = "sct"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1216,29 +1090,6 @@ checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
  "ring",
  "untrusted",
-]
-
-[[package]]
-name = "security-framework"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bc1bb97804af6631813c55739f771071e0f2ed33ee20b68c86ec505d906356c"
-dependencies = [
- "bitflags",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -1516,16 +1367,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1662,12 +1503,6 @@ dependencies = [
  "getrandom",
  "serde",
 ]
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1734,7 +1734,7 @@ dependencies = [
 
 [[package]]
 name = "yamis"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "assert_cmd",
  "assert_fs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,9 +242,9 @@ checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "digest"
-version = "0.10.3"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -677,9 +677,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.132"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "log"
@@ -688,6 +688,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "md-5"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6365506850d44bff6e2fbcb5176cf63650e48bd45ef2fe2665ae1570e0f4b9ca"
+dependencies = [
+ "digest",
 ]
 
 [[package]]
@@ -1495,16 +1504,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "uuid"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd6469f4314d5f1ffec476e05f17cc9a78bc7a27a6a857842170bdf8d6f98d2f"
-dependencies = [
- "getrandom",
- "serde",
-]
-
-[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1747,6 +1746,7 @@ dependencies = [
  "dotenv-parser",
  "indexmap",
  "lazy_static",
+ "md-5",
  "pest",
  "pest_derive",
  "petgraph",
@@ -1758,7 +1758,6 @@ dependencies = [
  "serde_yaml",
  "shellexpand",
  "toml",
- "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,6 +600,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87c48c02e0dc5e3b849a2041db3029fd066650f8f717c07bf8ed78ccb895cac"
+dependencies = [
+ "http",
+ "hyper",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+]
+
+[[package]]
 name = "hyper-tls"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1107,6 +1120,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "hyper-rustls",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -1116,17 +1130,57 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
  "winreg",
+]
+
+[[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin",
+ "untrusted",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
+name = "rustls"
+version = "0.20.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aab8ee6c7097ed6057f43c187a62418d0c05a4bd5f18b3571db50ee0f9ce033"
+dependencies = [
+ "log",
+ "ring",
+ "sct",
+ "webpki",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55"
+dependencies = [
+ "base64",
 ]
 
 [[package]]
@@ -1152,6 +1206,16 @@ checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
 dependencies = [
  "lazy_static",
  "windows-sys",
+]
+
+[[package]]
+name = "sct"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -1298,6 +1362,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "strsim"
@@ -1456,6 +1526,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
+dependencies = [
+ "rustls",
+ "tokio",
+ "webpki",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1554,6 +1635,12 @@ name = "unsafe-libyaml"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "931179334a56395bcf64ba5e0ff56781381c1a5832178280c7d7f91d1679aeb0"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
@@ -1698,6 +1785,25 @@ checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.22.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368bfe657969fb01238bb756d351dcade285e0f6fcbd36dcb23359a5169975be"
+dependencies = [
+ "webpki",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,19 +600,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-rustls"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d87c48c02e0dc5e3b849a2041db3029fd066650f8f717c07bf8ed78ccb895cac"
-dependencies = [
- "http",
- "hyper",
- "rustls",
- "tokio",
- "tokio-rustls",
-]
-
-[[package]]
 name = "hyper-tls"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1120,7 +1107,6 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-rustls",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -1130,57 +1116,17 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
- "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
  "winreg",
-]
-
-[[package]]
-name = "ring"
-version = "0.16.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
-dependencies = [
- "cc",
- "libc",
- "once_cell",
- "spin",
- "untrusted",
- "web-sys",
- "winapi",
-]
-
-[[package]]
-name = "rustls"
-version = "0.20.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aab8ee6c7097ed6057f43c187a62418d0c05a4bd5f18b3571db50ee0f9ce033"
-dependencies = [
- "log",
- "ring",
- "sct",
- "webpki",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55"
-dependencies = [
- "base64",
 ]
 
 [[package]]
@@ -1206,16 +1152,6 @@ checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
 dependencies = [
  "lazy_static",
  "windows-sys",
-]
-
-[[package]]
-name = "sct"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
-dependencies = [
- "ring",
- "untrusted",
 ]
 
 [[package]]
@@ -1362,12 +1298,6 @@ dependencies = [
  "libc",
  "winapi",
 ]
-
-[[package]]
-name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "strsim"
@@ -1526,17 +1456,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-rustls"
-version = "0.23.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
-dependencies = [
- "rustls",
- "tokio",
- "webpki",
-]
-
-[[package]]
 name = "tokio-util"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1635,12 +1554,6 @@ name = "unsafe-libyaml"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "931179334a56395bcf64ba5e0ff56781381c1a5832178280c7d7f91d1679aeb0"
-
-[[package]]
-name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
@@ -1785,25 +1698,6 @@ checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.22.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368bfe657969fb01238bb756d351dcade285e0f6fcbd36dcb23359a5169975be"
-dependencies = [
- "webpki",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ pest = "2.0"
 pest_derive = "2.0"
 indexmap = "1.9"
 shellexpand = "2.1.2"
-self_update = { version = "0.32", features = ["archive-tar", "archive-zip", "compression-flate2", "rustls"] }
+self_update = { version = "0.32", features = ["archive-tar", "archive-zip", "compression-flate2"] }
 directories = { version = "4.0" }
 
 # Example for adding another version as dependency. Need to remove the runtime feature, and make it optional

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ pest = "2.0"
 pest_derive = "2.0"
 indexmap = "1.9"
 shellexpand = "2.1.2"
-self_update = { version = "0.32", features = ["archive-tar", "archive-zip", "compression-flate2"] }
+self_update = { version = "0.32", features = ["archive-tar", "archive-zip", "compression-flate2", "rustls"] }
 directories = { version = "4.0" }
 
 # Example for adding another version as dependency. Need to remove the runtime feature, and make it optional

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ lazy_static = "1.4"
 serde_derive = "1.0"
 serde = {version = "1.0", features = ["derive"]}
 petgraph = "0.6"
-uuid = { version = "1.1", features = ["serde", "v4"] }
 ctrlc = "3.2"
 dotenv-parser = "0.1"
 clap = { version = "4.0", features = ["derive", "cargo"] }
@@ -37,6 +36,7 @@ indexmap = "1.9"
 shellexpand = "2.1.2"
 self_update = { version = "0.32", features = ["archive-tar", "archive-zip", "compression-flate2", "rustls"], default-features = false }
 directories = { version = "4.0" }
+md-5 = "0.10"  # Used for caching
 
 # Example for adding another version as dependency. Need to remove the runtime feature, and make it optional
 # yamis_v2 = { package="yamis",  version = "2.0", default-features = false, optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ pest = "2.0"
 pest_derive = "2.0"
 indexmap = "1.9"
 shellexpand = "2.1.2"
-self_update = { version = "0.32", features = ["archive-tar", "archive-zip", "compression-flate2", "rustls"] }
+self_update = { version = "0.32", features = ["archive-tar", "archive-zip", "compression-flate2", "rustls"], default-features = false }
 directories = { version = "4.0" }
 
 # Example for adding another version as dependency. Need to remove the runtime feature, and make it optional

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yamis"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2021"
 license = "GPL-3.0-only"
 authors = ["Adrian Martinez <adrianmrit@gmail.com>"]

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,5 +1,5 @@
 [target.x86_64-unknown-linux-gnu]
-pre-build = ["sudo apt-get install pkg-config libssl-dev"]
+pre-build = ["apt-get update & apt-get install -y pkg-config libssl-dev"]
 
 [target.x86_64-unknown-linux-musl]
-pre-build = ["sudo pacman -S pkg-config openssl"]
+pre-build = ["apt-get update & apt-get install -y pkg-config libssl-dev"]

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,2 +1,2 @@
 [target.x86_64-unknown-linux-gnu]
-pre-build = ["apt-get update & apt-get install -y pkg-config libssl-dev"]
+pre-build = ["apt-get update & apt-get install -y pkg-config"]

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,5 @@
+[target.x86_64-unknown-linux-gnu]
+pre-build = ["sudo apt-get install pkg-config libssl-dev"]
+
+[target.x86_64-unknown-linux-musl]
+pre-build = ["sudo pacman -S pkg-config openssl"]

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,2 +1,0 @@
-[target.x86_64-unknown-linux-gnu]
-pre-build = ["apt-get update & apt-get install -y pkg-config"]

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,5 +1,2 @@
 [target.x86_64-unknown-linux-gnu]
 pre-build = ["apt-get update & apt-get install -y pkg-config libssl-dev"]
-
-[target.x86_64-unknown-linux-musl]
-pre-build = ["apt-get update & apt-get install -y pkg-config libssl-dev"]

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@
   * [Task inheritance](#task-inheritance)
     * [Extending program arguments](#extending-program-arguments)
     * [Private tasks](#private-tasks)
+  * [Debug Options](#debug-options)
   * [List of functions](#list-of-functions)
     * [map](#map-function)
     * [join](#join-function)
@@ -228,15 +229,19 @@ If the task is still not found, it will look at `~/.yamis/user.yamis.toml` or `~
 
 <a name="script"></a>
 ### Script
+**⚠️Warning:**
+DO NOT PASS SENSITIVE INFORMATION AS PARAMETERS IN SCRIPTS. Scripts are stored in a file in the temporal
+directory of the system and is the job of the OS to delete it, however it is not guaranteed that that will
+be the case. So any argument passed will be persisted indefinitely.
+
 The `script` value inside a task will be executed in the command line (defaults to cmd in Windows
 and bash in Unix). Scripts can spawn multiple lines, and contain shell built-ins and programs. When
 passing multiple arguments, they will be expanded by default, the common example would be the `"{ $@ }"`
 tag which expands to all the passed arguments.
 
-**⚠️Warning:**
-Scripts are stored in a file in the temporal directory of the system and is the job of the OS to delete it,
-however it is not guaranteed that that will be the case. So any argument passed will be stored in the
-script file and could be persisted indefinitely.
+The generated scripts are stored in the temporal directory, and the filename will be a hash so that if the
+script was previously called with the same parameters, we can reuse the previous file, essentially working
+as a cache.
 
 <a name="auto-quoting"></a>
 #### Auto quoting
@@ -325,8 +330,7 @@ This is not prevented since it can be bypassed by using a script.
 Because escaping arguments properly can get really complex quickly, scripts are prone to fail if certain
 arguments are passed. To prevent classic errors, arguments are quoted by default (see
 [__Auto quoting__](https://github.com/adrianmrit/yamis#auto-quoting)), but this is not completely safe.
-Also, each time a script runs, a temporal batch or cmd file is created. Not a big deal, but an extra step
-nevertheless.
+Also, scripts are saved in the temporal directory, and might be persisted indefinitely.
 
 On the other hand, programs run in their own process with arguments passed directly to it, so there is no
 need to escape them. These can also be extended more easily, like by extending the arguments.
@@ -681,6 +685,16 @@ Tasks can be marked as private by setting `private = true`. Private tasks cannot
 for inheritance.
 
 
+<a name="debug-options"></a>
+### Debug Options
+Some debug options can be added at the task or file level under `debug_config`
+
+- `print_file_path`: Boolean, defined at the file level and false by default. If true, the absolute config file path will
+ be displayed when running a task
+- `print_task_name`: Boolean, defined at the task or file level, true by default. If true, the name of the task will be displayed
+ when tunning a task   
+
+
 <a name="list-of-functions"></a>
 ### List of functions
 List of predefined functions.
@@ -840,9 +854,6 @@ Not possible at the moment, unless you fork the repository and add your own (whi
 contribute so everyone benefits from it. While I have plans to add more functions in the future, allowing custom functions is not
 that straightforward and probably not worth the effort, perhaps it is better to use a separate script, i.e. python. I am open
 to suggestions.
-
-### I have a suggestion, but I don't know rust (or have other priorities), can I still contribute?
-Absolutely, you can open an issue with your suggestion and I will try to implement it if it sounds good. I am eager to get some feedback.
 
 <a name="Contributing"></a>
 ## Contributing

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,5 @@
 use clap::ArgAction;
-use colored::{ColoredString, Colorize};
+use colored::{Color, ColoredString, Colorize};
 use lazy_static::lazy_static;
 use serde_derive::Deserialize;
 use std::collections::hash_map::Entry;
@@ -13,6 +13,7 @@ use std::{env, fmt, fs};
 use regex::Regex;
 
 use crate::config_files::{ConfigFilePaths, ConfigFilesContainer};
+use crate::print_utils::YamisOutput;
 use crate::types::{DynErrResult, TaskArgs};
 use crate::updater;
 
@@ -421,8 +422,18 @@ pub fn exec() -> DynErrResult<()> {
     if matches.get_one::<bool>("update").cloned().unwrap_or(false) {
         updater::update()?;
         return Ok(());
-    } else if let Some(msg) = updater::check_update_available()? {
-        println!("{}", msg);
+    } else {
+        match updater::check_update_available() {
+            Ok(result) => {
+                if let Some(msg) = result {
+                    println!("{}", msg.yamis_prefix(Color::Blue));
+                }
+            }
+            Err(e) => {
+                let err_msg = format!("Error checking for updates: {}", e);
+                eprintln!("{}", err_msg.yamis_prefix(Color::Red));
+            }
+        }
     }
 
     let current_dir = env::current_dir()?;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,5 @@
 use clap::ArgAction;
-use colored::{Color, ColoredString, Colorize};
+use colored::{ColoredString, Colorize};
 use lazy_static::lazy_static;
 use serde_derive::Deserialize;
 use std::collections::hash_map::Entry;
@@ -240,6 +240,9 @@ impl ConfigFileContainers {
                     let task = config_file_lock.get_public_task(task);
                     match task {
                         Some(task) => {
+                            if config_file_lock.debug_config.print_file_path {
+                                println!("{}", &path.to_string_lossy().yamis_info());
+                            }
                             return match task.run(&args, &config_file_lock) {
                                 Ok(val) => Ok(val),
                                 Err(e) => {
@@ -426,12 +429,12 @@ pub fn exec() -> DynErrResult<()> {
         match updater::check_update_available() {
             Ok(result) => {
                 if let Some(msg) = result {
-                    println!("{}", msg.yamis_prefix(Color::Blue));
+                    println!("{}", msg.yamis_prefix_info());
                 }
             }
             Err(e) => {
                 let err_msg = format!("Error checking for updates: {}", e);
-                eprintln!("{}", err_msg.yamis_prefix(Color::Red));
+                eprintln!("{}", err_msg.yamis_error());
             }
         }
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -129,7 +129,7 @@ impl ConfigFileContainers {
             }
         };
 
-        let file = match File::open(&path) {
+        let file = match File::open(path) {
             Ok(file_contents) => file_contents,
             Err(e) => return Err(format!("There was an error reading the file:\n{}", e).into()),
         };
@@ -138,7 +138,7 @@ impl ConfigFileContainers {
             serde_yaml::from_reader(file)?
         } else {
             // A bytes list should be slightly faster than a string list
-            toml::from_slice(&fs::read(&path)?)?
+            toml::from_slice(&fs::read(path)?)?
         };
 
         Ok(result.version)
@@ -383,7 +383,7 @@ pub fn exec() -> DynErrResult<()> {
                 .short('l')
                 .long("list")
                 .help("Lists configuration files that can be reached from the current directory")
-                .conflicts_with_all(&["file"])
+                .conflicts_with_all(["file"])
                 .action(ArgAction::SetTrue),
         )
         .arg(
@@ -391,7 +391,7 @@ pub fn exec() -> DynErrResult<()> {
                 .short('t')
                 .long("list-tasks")
                 .help("Lists tasks")
-                .conflicts_with_all(&["task-info"])
+                .conflicts_with_all(["task-info"])
                 .action(ArgAction::SetTrue),
         )
         .arg(

--- a/src/config_files.rs
+++ b/src/config_files.rs
@@ -1,3 +1,4 @@
+use crate::debug_config::ConfigFileDebugConfig;
 use crate::defaults::default_quote;
 use crate::parser::EscapeMode;
 use crate::tasks::Task;
@@ -70,6 +71,11 @@ pub struct ConfigFile {
     /// Path of the file.
     #[serde(skip)]
     pub(crate) filepath: PathBuf,
+
+    /// Debug options
+    #[serde(default)]
+    pub(crate) debug_config: ConfigFileDebugConfig,
+
     #[serde(default)]
     /// Working directory. Defaults to the folder where the script runs.
     wd: Option<String>,

--- a/src/config_files.rs
+++ b/src/config_files.rs
@@ -362,14 +362,14 @@ impl ConfigFile {
                 .into());
             }
         };
-        let contents = match fs::read_to_string(&path) {
+        let contents = match fs::read_to_string(path) {
             Ok(file_contents) => file_contents,
             Err(e) => return Err(format!("There was an error reading the file:\n{}", e).into()),
         };
         if is_yaml {
-            Ok(serde_yaml::from_str(&*contents)?)
+            Ok(serde_yaml::from_str(&contents)?)
         } else {
-            Ok(toml::from_str(&*contents)?)
+            Ok(toml::from_str(&contents)?)
         }
     }
 

--- a/src/debug_config.rs
+++ b/src/debug_config.rs
@@ -38,6 +38,12 @@ impl Clone for TaskDebugConfig {
     }
 }
 
+/// Task debug options, but with no optional values
+/// This is used to avoid having to check for `None` values
+/// every time we want to use a debug option.
+///
+/// This is created by merging the relevant debug options
+/// from the config file and the task.
 pub(crate) struct ConcreteTaskDebugConfig {
     pub(crate) print_task_name: bool,
 }

--- a/src/debug_config.rs
+++ b/src/debug_config.rs
@@ -1,0 +1,61 @@
+use crate::defaults::{default_false, default_true};
+use serde_derive::Deserialize;
+
+/// Config file debug options
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ConfigFileDebugConfig {
+    /// Print the name of the task before running
+    #[serde(default = "default_true")]
+    pub(crate) print_task_name: bool,
+    /// Print the config file path when it is initialized
+    #[serde(default = "default_false")]
+    pub(crate) print_file_path: bool,
+}
+
+impl Default for ConfigFileDebugConfig {
+    fn default() -> Self {
+        Self {
+            print_task_name: true,
+            print_file_path: false,
+        }
+    }
+}
+
+/// Task debug options
+#[derive(Debug, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct TaskDebugConfig {
+    /// Name of the task
+    pub(crate) print_task_name: Option<bool>,
+}
+
+impl Clone for TaskDebugConfig {
+    fn clone(&self) -> Self {
+        Self {
+            print_task_name: self.print_task_name,
+        }
+    }
+}
+
+pub(crate) struct ConcreteTaskDebugConfig {
+    pub(crate) print_task_name: bool,
+}
+
+impl ConcreteTaskDebugConfig {
+    pub(crate) fn new(
+        task_debug_config: &Option<TaskDebugConfig>,
+        config_file_debug_config: &ConfigFileDebugConfig,
+    ) -> ConcreteTaskDebugConfig {
+        let task_debug_config = match task_debug_config {
+            Some(task_debug_config) => task_debug_config.clone(),
+            None => TaskDebugConfig::default(),
+        };
+
+        ConcreteTaskDebugConfig {
+            print_task_name: task_debug_config
+                .print_task_name
+                .unwrap_or(config_file_debug_config.print_task_name),
+        }
+    }
+}

--- a/src/defaults.rs
+++ b/src/defaults.rs
@@ -5,10 +5,10 @@ pub(crate) fn default_quote() -> EscapeMode {
     EscapeMode::Always
 }
 
-// /// Returns true, for serde deserialization defaults
-// pub(crate) fn default_true() -> bool {
-//     true
-// }
+/// Returns true, for serde deserialization defaults
+pub(crate) fn default_true() -> bool {
+    true
+}
 
 /// Returns false, for serde deserialization defaults
 pub(crate) fn default_false() -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ extern crate core;
 pub mod cli;
 
 pub mod config_files;
+pub(crate) mod debug_config;
 mod defaults;
 mod format_str;
 mod parser;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,4 @@
 #[cfg(feature = "runtime")]
-use colored::Colorize;
 use yamis::print_utils::YamisOutput;
 
 #[cfg(feature = "runtime")]
@@ -10,8 +9,7 @@ fn main() {
     match exec() {
         Ok(_) => {}
         Err(e) => {
-            let err_msg = e.to_string().red();
-            eprint!("{}", err_msg.yamis_prefix(colored::Color::Red));
+            eprint!("{}", e.to_string().yamis_error());
             std::process::exit(1);
         }
     }

--- a/src/print_utils.rs
+++ b/src/print_utils.rs
@@ -14,7 +14,9 @@ impl YamisOutput for str {
 
         let mut result = String::new();
         for line in lines {
-            result.push_str(&format!("{} {}", prefix, line));
+            result.push_str(&prefix);
+            result.push(' ');
+            result.push_str(line);
         }
         result
     }

--- a/src/print_utils.rs
+++ b/src/print_utils.rs
@@ -1,14 +1,31 @@
 use colored::{Color, ColoredString, Colorize};
 
 const PREFIX: &str = "[YAMIS]";
+const INFO_COLOR: Color = Color::BrightBlue;
+const WARN_COLOR: Color = Color::BrightYellow;
+const ERROR_COLOR: Color = Color::BrightRed;
 
 pub trait YamisOutput {
     /// Returns the given string with the `[YAMIS]` prefix in each line. The prefix will also take the given color.
-    fn yamis_prefix<S: Into<Color>>(&self, color: S) -> String;
+    fn yamis_prefix<S: Into<Color> + Clone>(&self, color: S) -> String;
+    /// Adds the `[YAMIS]` prefix to the given string. The whole string will have the given color.
+    fn yamis_colorize<S: Into<Color> + Clone>(&self, color: S) -> String;
+    /// Returns the given string with the `[YAMIS]` prefix in each line. The whole string will be blue.
+    fn yamis_info(&self) -> String;
+    /// Returns the given string with the `[YAMIS]` prefix in each line. The prefix will be blue.
+    fn yamis_prefix_info(&self) -> String;
+    /// Returns the given string with the `[YAMIS]` prefix in each line. The whole string will be yellow.
+    fn yamis_warn(&self) -> String;
+    /// Returns the given string with the `[YAMIS]` prefix in each line. The prefix will be yellow.
+    fn yamis_prefix_warn(&self) -> String;
+    /// Returns the given string with the `[YAMIS]` prefix in each line. The whole string will be red.
+    fn yamis_error(&self) -> String;
+    /// Returns the given string with the `[YAMIS]` prefix in each line. The prefix will be red.
+    fn yamis_prefix_error(&self) -> String;
 }
 
 impl YamisOutput for str {
-    fn yamis_prefix<S: Into<Color>>(&self, color: S) -> String {
+    fn yamis_prefix<S: Into<Color> + Clone>(&self, color: S) -> String {
         let lines = self.split_inclusive('\n');
         let prefix = PREFIX.color(color).to_string();
 
@@ -20,50 +37,128 @@ impl YamisOutput for str {
         }
         result
     }
+
+    fn yamis_colorize<S: Into<Color> + Clone>(&self, color: S) -> String {
+        let lines = self.split_inclusive('\n');
+
+        let mut result = String::new();
+        for line in lines {
+            result.push_str(PREFIX);
+            result.push(' ');
+            result.push_str(line);
+        }
+        result.color(color).to_string()
+    }
+
+    fn yamis_info(&self) -> String {
+        self.yamis_colorize(INFO_COLOR)
+    }
+
+    fn yamis_prefix_info(&self) -> String {
+        self.yamis_prefix(INFO_COLOR)
+    }
+
+    fn yamis_warn(&self) -> String {
+        self.yamis_colorize(WARN_COLOR)
+    }
+
+    fn yamis_prefix_warn(&self) -> String {
+        self.yamis_prefix(WARN_COLOR)
+    }
+
+    fn yamis_error(&self) -> String {
+        self.yamis_colorize(ERROR_COLOR)
+    }
+
+    fn yamis_prefix_error(&self) -> String {
+        self.yamis_prefix(ERROR_COLOR)
+    }
 }
 
 // Calling the function in a ColoredString instance removes the color from it,
 // so we need to transform it to a string first to keep it.
 impl YamisOutput for ColoredString {
-    fn yamis_prefix<S: Into<Color>>(&self, color: S) -> String {
+    fn yamis_prefix<S: Into<Color> + Clone>(&self, color: S) -> String {
         self.to_string().yamis_prefix(color)
+    }
+
+    fn yamis_colorize<S: Into<Color> + Clone>(&self, color: S) -> String {
+        self.to_string().yamis_colorize(color)
+    }
+
+    fn yamis_info(&self) -> String {
+        self.to_string().yamis_info()
+    }
+
+    fn yamis_prefix_info(&self) -> String {
+        self.to_string().yamis_prefix_info()
+    }
+
+    fn yamis_warn(&self) -> String {
+        self.to_string().yamis_warn()
+    }
+
+    fn yamis_prefix_warn(&self) -> String {
+        self.to_string().yamis_prefix_warn()
+    }
+
+    fn yamis_error(&self) -> String {
+        self.to_string().yamis_error()
+    }
+
+    fn yamis_prefix_error(&self) -> String {
+        self.to_string().yamis_prefix_error()
     }
 }
 
 #[test]
 fn test_yamis_prefix() {
-    let prefix = PREFIX.color(Color::Red);
+    let info_prefix = PREFIX.color(INFO_COLOR);
+    let warn_prefix = PREFIX.color(WARN_COLOR);
+    let error_prefix = PREFIX.color(ERROR_COLOR);
+
     let output = "\nThis is a test\n\nThis is another test\n\n".to_string();
-    let colored_output = output.yamis_prefix(Color::Red);
+    let colored_output = output.yamis_prefix_error();
     let expected_output = format!(
-        "{prefix} \n{prefix} This is a test\n{prefix} \n{prefix} This is another test\n{prefix} \n"
+        "{error_prefix} \n{error_prefix} This is a test\n{error_prefix} \n{error_prefix} This is another test\n{error_prefix} \n"
     );
     assert_eq!(colored_output, expected_output);
 
     let output = "This is a test\nThis is another test";
-    let colored_output = output.yamis_prefix(Color::Red);
-    let expected_output = format!("{prefix} This is a test\n{prefix} This is another test");
+    let colored_output = output.yamis_prefix_error();
+    let expected_output =
+        format!("{error_prefix} This is a test\n{error_prefix} This is another test");
     assert_eq!(colored_output, expected_output);
 
-    let colored_text = "This is a test".color(Color::Red);
+    let output = "This is a test\nThis is another test";
+    let colored_output = output.yamis_error();
+    let expected_output = format!("{PREFIX} This is a test\n{PREFIX} This is another test")
+        .color(ERROR_COLOR)
+        .to_string();
+    assert_eq!(colored_output, expected_output);
+
+    let colored_text = "This is a test".color(Color::Blue);
     let output = format!("{colored_text}\nThis is another test");
-    let colored_output = output.yamis_prefix(Color::Red);
-    let expected_output = format!("{prefix} {colored_text}\n{prefix} This is another test");
+    let colored_output = output.yamis_prefix_warn();
+    let expected_output =
+        format!("{warn_prefix} {colored_text}\n{warn_prefix} This is another test");
     assert_eq!(colored_output, expected_output);
 
     let output = "This is a test\n";
-    let colored_output = output.yamis_prefix(Color::Red);
-    let expected_output = format!("{prefix} This is a test\n");
+    let colored_output = output.yamis_prefix_info();
+    let expected_output = format!("{info_prefix} This is a test\n");
     assert_eq!(colored_output, expected_output);
 
     let output = "This is a test";
-    let colored_output = output.yamis_prefix(Color::Red);
-    let expected_output = format!("{prefix} This is a test");
+    let colored_output = output.yamis_info();
+    let expected_output = format!("{PREFIX} This is a test")
+        .color(INFO_COLOR)
+        .to_string();
     assert_eq!(colored_output, expected_output);
 
     let output = "\n\n";
-    let colored_output = output.yamis_prefix(Color::Red);
-    let expected_output = format!("{prefix} \n{prefix} \n");
+    let colored_output = output.yamis_prefix_info();
+    let expected_output = format!("{info_prefix} \n{info_prefix} \n");
     assert_eq!(colored_output, expected_output);
 
     let output = "";

--- a/src/print_utils.rs
+++ b/src/print_utils.rs
@@ -10,7 +10,7 @@ pub trait YamisOutput {
 impl YamisOutput for str {
     fn yamis_prefix<S: Into<Color>>(&self, color: S) -> String {
         let lines = self.split_inclusive('\n');
-        let prefix = PREFIX.color(color);
+        let prefix = PREFIX.color(color).to_string();
 
         let mut result = String::new();
         for line in lines {

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -5,16 +5,16 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::Arc;
-use std::{error, fmt, mem};
+use std::{error, fmt, fs, mem};
 
 use crate::config_files::ConfigFile;
 use crate::defaults::default_false;
 use crate::parser::{parse_params, parse_script, EscapeMode};
 use serde_derive::Deserialize;
-use uuid::Uuid;
 
 use crate::types::{DynErrResult, TaskArgs};
-use crate::utils::{get_path_relative_to_base, read_env_file};
+use crate::utils::{get_path_relative_to_base, read_env_file, TMP_FOLDER_NAMESPACE};
+use md5::{Digest, Md5};
 
 cfg_if::cfg_if! {
     if #[cfg(target_os = "windows")] {
@@ -130,8 +130,15 @@ cfg_if::cfg_if! {
 /// # Arguments
 ///
 /// * `content` - Content of the script file
-fn get_temp_script(content: &str, extension: &str) -> DynErrResult<PathBuf> {
+fn get_temp_script(
+    content: &str,
+    extension: &str,
+    task_name: &str,
+    config_file_path: &Path,
+) -> DynErrResult<PathBuf> {
     let mut path = temp_dir();
+    path.push(TMP_FOLDER_NAMESPACE);
+    fs::create_dir_all(&path)?;
 
     let extension = if extension.is_empty() {
         String::new()
@@ -141,9 +148,22 @@ fn get_temp_script(content: &str, extension: &str) -> DynErrResult<PathBuf> {
         format!(".{}", extension)
     };
 
-    let file_name = format!("{}-yamis{}", Uuid::new_v4(), extension);
-    path.push(file_name);
+    // get md5 hash of the task_name, config_file_path and content
+    let mut hasher = Md5::new();
+    hasher.update(task_name.as_bytes());
+    hasher.update(config_file_path.to_str().unwrap().as_bytes());
+    hasher.update(content.as_bytes());
+    let hash = hasher.finalize();
 
+    let file_name = format!("{:X}{}", hash, extension);
+    path.push(file_name);
+    dbg!(&path);
+
+    // Uses the temp file as a cache, so it doesn't have to create it every time
+    // we run the same script.
+    if path.exists() {
+        return Ok(path);
+    }
     let mut file = create_script_file(&path)?;
     file.write_all(content.as_bytes())?;
     Ok(path)
@@ -464,7 +484,12 @@ impl Task {
 
         match parse_script(script, args, &env, quote) {
             Ok(script) => {
-                let script_file = get_temp_script(&script, script_extension)?;
+                let script_file = get_temp_script(
+                    &script,
+                    script_extension,
+                    &self.name,
+                    &config_file.filepath.as_path(),
+                )?;
                 command.arg(script_file.to_str().unwrap());
             }
             Err(e) => {
@@ -893,23 +918,31 @@ Second line
 
     #[test]
     fn test_create_temp_script() {
+        let tmp_dir = TempDir::new().unwrap();
+        let project_config_path = tmp_dir.join("project.yamis.toml");
         let script = "echo hello world";
         let extension = "sh";
-        let script_path = get_temp_script(script, extension).unwrap();
+        let task_name = "sample";
+        let script_path =
+            get_temp_script(script, extension, task_name, project_config_path.as_path()).unwrap();
         assert!(script_path.exists());
         assert_eq!(script_path.extension().unwrap(), extension);
         let script_content = fs::read_to_string(script_path).unwrap();
         assert_eq!(script_content, script);
 
         let extension = "";
-        let script_path = get_temp_script(script, extension).unwrap();
+        let task_name = "sample2";
+        let script_path =
+            get_temp_script(script, extension, task_name, project_config_path.as_path()).unwrap();
         assert!(script_path.exists());
         assert!(script_path.extension().is_none());
         let script_content = fs::read_to_string(script_path).unwrap();
         assert_eq!(script_content, script);
 
         let extension = ".sh";
-        let script_path = get_temp_script(script, extension).unwrap();
+        let task_name = "sample3";
+        let script_path =
+            get_temp_script(script, extension, task_name, project_config_path.as_path()).unwrap();
         assert!(script_path.exists());
         assert_eq!(script_path.extension().unwrap(), "sh");
         let script_content = fs::read_to_string(script_path).unwrap();

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -488,7 +488,7 @@ impl Task {
                     &script,
                     script_extension,
                     &self.name,
-                    &config_file.filepath.as_path(),
+                    config_file.filepath.as_path(),
                 )?;
                 command.arg(script_file.to_str().unwrap());
             }

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -114,7 +114,6 @@ pub(crate) fn check_update_available() -> DynErrResult<Option<String>> {
     if cache_file.outdated() {
         #[cfg(not(test))]
         {
-            dbg!("Checking for updates");
             let releases = self_update::backends::github::ReleaseList::configure()
                 .repo_owner("adrianmrit")
                 .repo_name("yamis")
@@ -146,8 +145,6 @@ pub(crate) fn check_update_available() -> DynErrResult<Option<String>> {
             url = LATEST_RELEASE_URL.yellow(),
             inst = update_instructions
         );
-
-        let msg = msg.yamis_prefix(Color::Blue);
 
         Some(msg)
     } else {

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -1,5 +1,5 @@
 use crate::types::DynErrResult;
-use colored::{Color, Colorize};
+use colored::Colorize;
 use self_update::cargo_crate_version;
 use self_update::version::bump_is_greater;
 use std::fs::create_dir_all;

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -6,7 +6,6 @@ use std::fs::create_dir_all;
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use crate::print_utils::YamisOutput;
 #[cfg(test)]
 use assert_fs::TempDir;
 #[cfg(not(test))]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -167,7 +167,6 @@ mod tests {
         let mut file = File::create(&env_file_path).unwrap();
         file.write_all(r#"INVALID_ENV_FILE"#.as_bytes()).unwrap();
         let env_map = read_env_file(&env_file_path).unwrap_err();
-        dbg!(env_map.to_string());
         let expected_err = format!("Failed to parse env file at {}: ", env_file_path.display());
         assert!(env_map.to_string().contains(&expected_err),);
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,6 +7,8 @@ use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 use std::{env, fs};
 
+/// To uniquely identify the temporary folder. Constant so that the scripts are cached.
+pub const TMP_FOLDER_NAMESPACE: &str = "adrianmrit.yamis";
 /// Returns the task name as per the current OS.
 ///
 /// # Arguments


### PR DESCRIPTION
Saves the temporal script files with an md5 hash so that they can be reused easily